### PR TITLE
Filtered stock data before save

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1144,6 +1144,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
 
             // Format bunch to stock data rows
             foreach ($bunch as $rowNum => $rowData) {
+                $this->_filterRowData($rowData);
                 if (!$this->isRowAllowedToImport($rowData, $rowNum)) {
                     continue;
                 }


### PR DESCRIPTION
Stock data was not being filtered and so values with ###IGNORE### or
### EMPTY### (or whatever token is set for those) was being used as

values for the database and hence overwriting stock data values when
user was not updating them in CSV.
